### PR TITLE
Fix bootstrap jquery load order

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
     <link rel="stylesheet" href="css/style.css">
     <link href='https://fonts.googleapis.com/css?family=Lato:400,900' rel='stylesheet' type='text/css'>
 
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
     <script src="https://code.jquery.com/jquery-2.1.4.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
     <script src="js/index.js"></script>
 </head>
 


### PR DESCRIPTION
## Summary
- ensure jQuery is loaded before Bootstrap so plugins init correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849daa214f0833385872026973b2fcd